### PR TITLE
config: Fix support for multiple levels of same layer

### DIFF
--- a/packages/config/test/async.test.js
+++ b/packages/config/test/async.test.js
@@ -490,4 +490,37 @@ describe('async', () => {
 
         return expect(actual).to.eventually.deep.equal(expected);
     });
+
+    it('should return levels set with custom paths', () => {
+        const bemConfig = config([{
+            levels: [
+                { layer: 'common', path: 'node_modules/lib/common.blocks' },
+                { layer: 'common', path: 'common.blocks' },
+                { layer: 'desktop', path: 'desktop.blocks' }
+            ],
+            sets: {
+                desktop: 'common desktop'
+            },
+            __source: path.join(process.cwd(), path.basename(__filename))
+        }]);
+
+        const expected = [
+            {
+                layer: 'common',
+                path: path.resolve('node_modules/lib/common.blocks')
+            },
+            {
+                layer: 'common',
+                path: path.resolve('common.blocks')
+            },
+            {
+                layer: 'desktop',
+                path: path.resolve('desktop.blocks')
+            }
+        ];
+
+        const actual = bemConfig().levels('desktop');
+
+        return expect(actual).to.eventually.deep.equal(expected);
+    });
 });

--- a/packages/config/test/sync.test.js
+++ b/packages/config/test/sync.test.js
@@ -468,4 +468,37 @@ describe('sync', () => {
 
         expect(actual).to.deep.equal(expected);
     });
+
+    it('should return levels set with custom paths', () => {
+        const bemConfig = config([{
+            levels: [
+                { layer: 'common', path: 'node_modules/lib/common.blocks' },
+                { layer: 'common', path: 'common.blocks' },
+                { layer: 'desktop', path: 'desktop.blocks' }
+            ],
+            sets: {
+                desktop: 'common desktop'
+            },
+            __source: path.join(process.cwd(), path.basename(__filename))
+        }]);
+
+        const expected = [
+            {
+                layer: 'common',
+                path: path.resolve('node_modules/lib/common.blocks')
+            },
+            {
+                layer: 'common',
+                path: path.resolve('common.blocks')
+            },
+            {
+                layer: 'desktop',
+                path: path.resolve('desktop.blocks')
+            }
+        ];
+
+        const actual = bemConfig().levelsSync('desktop');
+
+        expect(actual).to.deep.equal(expected);
+    });
 });


### PR DESCRIPTION
Closes #294

Note: actually multiple levels of same layer is kinda antipattern which will be harmful in the future (see https://github.com/bem/bem-sdk/pull/295#discussion_r176905828).

But right now we decided to keep it to use with libs without own `.bemrc`. In other cases should be possible to merge semantically identical layers into one folder.