### PR TITLE
Fix lerna3 error in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 
 install:
   - npm i -g lerna
-  - lerna bootstrap
+  - lerna bootstrap --no-ci
 
 after_success:
   - if [ "x$COVERALLS" = "x1" ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - node --version
   - npm --version
   - npm install lerna
-  - ./node_modules/.bin/lerna bootstrap -- --force
+  - ./node_modules/.bin/lerna bootstrap --no-ci -- --force
 
 test_script:
   - ./node_modules/.bin/lerna run test


### PR DESCRIPTION
Stack trace of error:

```
lerna ERR! npm ci --no-package-lock --no-ci exited 1 in '@bem/sdk'
lerna ERR! npm ci --no-package-lock --no-ci stderr:
npm ERR! cipm can only install packages with an existing package-lock.json or npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or later to generate it, then try again.
```