### PR TITLE
Add README for naming.file.stringify package

### DIFF
--- a/packages/naming.cell.stringify/README.md
+++ b/packages/naming.cell.stringify/README.md
@@ -1,4 +1,4 @@
-# stringify
+# naming.cell.stringify
 
 Stringifier for a BEM cell object.
 
@@ -17,7 +17,7 @@ Stringifier for a BEM cell object.
 
 Stringify returns the file path for a specified BEM cell object.
 
-You can choose a preset with [naming convention](https://en.bem.info/methodology/naming-convention/) for creating a `stingify()` function. See the full list of supported presets in the `@bem/sdk.naming.presets` package [documentation](https://github.com/bem/bem-sdk/tree/migelle-naming-presets-doc/packages/naming.presets#naming-conventions).
+You can choose a preset with [naming convention](https://en.bem.info/methodology/naming-convention/) for creating a `stingify()` function. See the full list of supported presets in the `@bem/sdk.naming.presets` package [documentation](https://github.com/bem/bem-sdk/tree/master/packages/naming.presets#naming-conventions).
 
 All provided presets uses the [`nested`](https://en.bem.info/methodology/filestructure/#nested) file structure scheme. To use the [`flat`](https://en.bem.info/methodology/filestructure/#flat) scheme that is better for small projects, see [Using a custom naming convention](#using-a-custom-naming-convention) section.
 
@@ -57,7 +57,7 @@ $ npm install --save @bem/sdk.naming.cell.stringify @bem/sdk.naming.presets @bem
 Create a JavaScript file with any name (for example, **app.js**) and do the following:
 
 1. Choose the [naming convention](https://bem.info/methodology/naming-convention/) and import the preset with this convention (for example, origin naming convention).
-    See the full list of supported presets in the `@bem/sdk.naming.presets` package [documentation](https://github.com/bem/bem-sdk/tree/migelle-naming-presets-doc/packages/naming.presets#naming-conventions).
+    See the full list of supported presets in the `@bem/sdk.naming.presets` package [documentation](https://github.com/bem/bem-sdk/tree/master/packages/naming.presets#naming-conventions).
 1. Import the `@bem/sdk.naming.cell.stringify` package and create the `stringify()` function using the imported preset:
 
 ```js
@@ -67,11 +67,13 @@ const stringify = require('@bem/sdk.naming.cell.stringify')(originNaming);
 
 ### Creating a BEM cell object
 
-Create a BEM cell object to stringify.
+Create a BEM cell object to stringify. You can use the [create()](https://github.com/bem/bem-sdk/tree/master/packages/cell#createobject) function from the `@bem/sdk.cell` package.
 
 ```js
 const BemCell = require('@bem/sdk.cell');
-const blockModifier = BemCell.create({block: 'my-block', mod: 'my-modifier', tech: 'css' });
+
+var myBemCell;
+myBemCell = BemCell.create({block: 'my-block', tech: 'css' });
 ```
 
 ### Getting a file path
@@ -79,12 +81,12 @@ const blockModifier = BemCell.create({block: 'my-block', mod: 'my-modifier', tec
 Stringify the created BEM cell object:
 
 ```js
-stringify(blockModifier);
+stringify(myBemCell);
 ```
 
-This function will return the string with file path `common.blocks/my-block/_my-modifier/my-block_my-modifier.css`.
+This function will return the string with file path `common.blocks/my-block/my-block.css`.
 
-**Example**:
+**Example:**
 
 ```js
 const originNaming = require('@bem/sdk.naming.presets/origin');
@@ -93,8 +95,7 @@ const stringify = require('@bem/sdk.naming.cell.stringify')(originNaming);
 const BemCell = require('@bem/sdk.cell');
 
 var myBemCell;
-myBemCell = BemCell.create({block: 'my-block',
-                            tech: 'css' });
+myBemCell = BemCell.create({block: 'my-block', tech: 'css' });
 console.log(stringify(myBemCell));
 // => common.blocks/my-block/my-block.css
 
@@ -144,11 +145,10 @@ console.log(stringify(myBemCell));
 
 ```js
 /**
- * @typedef BemCell
- * @param {Object} obj — representation of cell.
- * @param {BemEntityName} obj.entity — representation of entity name.
- * @param {string} obj.tech - tech of cell.
- * @param {string} [obj.layer] - layer of cell.
+ * @typedef BemCell — representation of cell.
+ * @property {BemEntityName} entity — representation of entity name.
+ * @property {string} tech - tech of cell.
+ * @property {string} [obj.layer] - layer of cell.
  */
 
 /**

--- a/packages/naming.file.stringify/README.md
+++ b/packages/naming.file.stringify/README.md
@@ -1,29 +1,225 @@
 # naming.file.stringify
 
-[BEM file system](https://en.bem.info/method/filesystem/#principles-of-file-system-organization-for-bem-projects) [schemes](https://en.bem.info/faq/#why-create-separate-directories-and-files-for-every-block-and-technology).
+Stringifier for a BEM file.
 
-## Usage
+[![NPM Status][npm-img]][npm]
+
+[npm]:          https://www.npmjs.org/package/@bem/sdk.naming.file.stringify
+[npm-img]:      https://img.shields.io/npm/v/@bem/sdk.naming.file.stringify.svg
+
+* [Introduction](#introduction)
+* [Try stringify](#try-stringify)
+* [Quick start](#quick-start)
+* [API reference](#api-reference)
+* [Parameter tuning](#parameter-tuning)
+
+## Introduction
+
+Stringify returns the file path for a specified BEM file object.
+
+You can choose a preset with [naming convention](https://en.bem.info/methodology/naming-convention/) for creating a `stingify()` function. See the full list of supported presets in the `@bem/sdk.naming.presets` package [documentation](https://github.com/bem/bem-sdk/tree/master/packages/naming.presets#naming-conventions).
+
+All provided presets uses the [`nested`](https://en.bem.info/methodology/filestructure/#nested) file structure scheme. To use the [`flat`](https://en.bem.info/methodology/filestructure/#flat) scheme that is better for small projects, see [Using a custom naming convention](#using-a-custom-naming-convention) section.
+
+> **Note.** If you don't have any BEM projects available to try out the `@bem/sdk.naming.file.stringify` package, the quickest way to create one is to use [bem-express](https://github.com/bem/bem-express).
+
+## Try stringify
+
+An example is available in the [RunKit editor](https://runkit.com/migs911/how-bem-sdk-naming-file-stringify-works).
+
+## Quick start
+
+> **Attention.** To use `@bem/sdk.naming.file.stringify`, you must install [Node.js 8.0+](https://nodejs.org/en/download/).
+
+To run the `@bem/sdk.naming.file.stringify` package:
+
+1. [Install required packages](#installing-required-packages).
+2. [Create a `stringify()` function](#creating-a-stringify-function).
+3. [Create a BEM file object](#creating-a-bem-file-object).
+4. [Getting a file path](#getting-a-file-path).
+
+### Installing required packages
+
+Install the following packages:
+
+* [@bem/sdk.naming.file.stringify](https://www.npmjs.org/package/@bem/sdk.naming.file.stringify) that makes the `stingify()` function.
+* [@bem/sdk.naming.presets](https://www.npmjs.com/package/@bem/sdk.naming.presets) that contains presets with well-known naming conventions.
+* [@bem/sdk.file](https://www.npmjs.com/package/@bem/sdk.file) that allows you create a BEM file objects to stringify.
+
+To install these packages, run the following command:
+
+```
+$ npm install --save @bem/sdk.naming.file.stringify @bem/sdk.naming.presets @bem/sdk.file
+```
+
+### Creating a `stringify()` function
+
+Create a JavaScript file with any name (for example, **app.js**) and do the following:
+
+1. Choose the [naming convention](https://bem.info/methodology/naming-convention/) and import the preset with this convention (for example, origin naming convention).
+    See the full list of supported presets in the `@bem/sdk.naming.presets` package [documentation](https://github.com/bem/bem-sdk/tree/master/packages/naming.presets#naming-conventions).
+1. Import the `@bem/sdk.naming.file.stringify` package and create the `stringify()` function using the imported preset:
+
+```js
+const originNaming = require('@bem/sdk.naming.presets/origin');
+const stringify = require('@bem/sdk.naming.file.stringify')(originNaming);
+```
+
+### Creating a BEM file object
+
+Create a BEM file object to stringify. You can use the [create()](https://github.com/bem/bem-sdk/tree/master/packages/file#createobject) function from the `@bem/sdk.file` package.
 
 ```js
 const BemFile = require('@bem/sdk.file');
 
-const file = new BemFile({
-    cell: {
-        block: 'b1',
-        elem: 'e1',
-        mod: {name: 'm1', val: 'v1'},
-        tech: 'js',
-        layer: 'desktop'
-    },
-    level: 'node_modules/bem-core'
-});
-
-const stringify = require('@bem/sdk.naming.file.stringify')(require('@bem/sdk.naming.presets/origin'));
-
-stringify(file); // node_modules/bem-core/desktop.blocks/b1/__e1/_m1/b1__e1_m1_v1.js
+var myFile;
+myFile = BemFile.create({block: 'my-block', tech: 'css' });
 ```
 
-License
--------
+### Getting a file path
 
-Code and documentation © 2017 YANDEX LLC. Code released under the [Mozilla Public License 2.0](LICENSE.txt).
+Stringify the created BEM file object:
+
+```js
+stringify(myFile);
+```
+
+This function will return the string with file path `common.blocks/my-block/my-block.css`.
+
+**Example:**
+
+```js
+const originNaming = require('@bem/sdk.naming.presets/origin');
+const stringify = require('@bem/sdk.naming.file.stringify')(originNaming);
+
+const BemFile = require('@bem/sdk.file');
+
+var myFile;
+myFile = BemFile.create({block: 'my-block', tech: 'css' });
+console.log(stringify(myFile));
+// => common.blocks/my-block/my-block.css
+
+myFile = BemFile.create({block: 'my-block',
+                         tech: 'js',
+                         level: 'bem-files'});
+console.log(stringify(myFile));
+// => bem-files/common.blocks/my-block/my-block.js
+
+myFile = BemFile.create({block: 'my-block',
+                         tech: 'css',
+                         layer: 'desktop',
+                         level: 'bem-files'});
+console.log(stringify(myFile));
+// => bem-files/desktop.blocks/my-block/my-block.css
+
+myFile = BemFile.create({block: 'my-block',
+                         tech: 'css',
+                         level: 'my-project/bem-files'});
+console.log(stringify(myFile));
+// => my-project/bem-files/common.blocks/my-block/my-block.css
+
+myFile = BemFile.create({block: 'my-block',
+                         mod: 'my-modifier',
+                         val: 'some-value',
+                         tech: 'css',
+                         level: 'bem-files'});
+console.log(stringify(myFile));
+// => bem-files/common.blocks/my-block/_my-modifier/my-block_my-modifier_some-value.css
+
+myFile = BemFile.create({block: 'my-block',
+                         elem: 'my-element',
+                         mod: 'my-modifier',
+                         tech: 'css',
+                         level: 'bem-files' });
+console.log(stringify(myFile));
+// => bem-files/common.blocks/my-block/__my-element/_my-modifier/my-block__my-element_my-modifier.css
+```
+
+[RunKit live example](https://runkit.com/migs911/naming-file-stringify-using-origin-convention).
+
+## API reference
+
+### stringify()
+
+```js
+/**
+ * @typedef BemFile — representation of file.
+ * @property {BemCell} cell — representation of a BEM cell.
+ * @property {String} [level] - base level path.
+ * @property {String} [path] - path to file.
+ */
+
+/**
+ * Forms a file according to object representation of BEM file.
+ *
+ * @param {Object|BemFile} file - object representation of BEM file.
+ * @returns {string} - file path.
+ */
+stringify(file);
+```
+
+## Parameter tuning
+
+### Using a custom naming convention
+
+To create a preset with a custom naming convention use the `create()` function from the `@bem/sdk.naming.presets` package.
+
+For example create a preset that uses [`flat`](https://en.bem.info/methodology/filestructure/#flat) scheme to describe a file structure organization.
+
+Use the created preset to make your `stingify()` function.
+
+**Example:**
+
+```js
+const options = {
+        fs: { scheme: 'flat' }
+    };
+const originFlatNaming = require('@bem/sdk.naming.presets/create')(options);
+const stringify = require('@bem/sdk.naming.file.stringify')(originFlatNaming);
+
+const BemFile = require('@bem/sdk.file');
+
+var myFile;
+myFile = BemFile.create({block: 'my-block', tech: 'css' });
+console.log(stringify(myFile));
+// => common.blocks/my-block.css
+
+myFile = BemFile.create({block: 'my-block',
+                     tech: 'js',
+                     level: 'bem-files'});
+console.log(stringify(myFile));
+// => bem-files/common.blocks/my-block.js
+
+myFile = BemFile.create({block: 'my-block',
+                     tech: 'css',
+                     layer: 'desktop',
+                     level: 'bem-files'});
+console.log(stringify(myFile));
+// => bem-files/desktop.blocks/my-block.css
+
+myFile = BemFile.create({block: 'my-block',
+                     tech: 'css',
+                     level: 'my-project/bem-files'});
+console.log(stringify(myFile));
+// => my-project/bem-files/common.blocks/my-block.css
+
+myFile = BemFile.create({block: 'my-block',
+                     mod: 'my-modifier',
+                     val: 'some-value',
+                     tech: 'css',
+                     level: 'bem-files'});
+console.log(stringify(myFile));
+// => bem-files/common.blocks/my-block_my-modifier_some-value.css
+
+myFile = BemFile.create({block: 'my-block',
+                     elem: 'my-element',
+                     mod: 'my-modifier',
+                     tech: 'css',
+                     level: 'bem-files' });
+console.log(stringify(myFile));
+// => bem-files/common.blocks/my-block__my-element_my-modifier.css
+```
+
+[RunKit live example](https://runkit.com/migs911/naming-file-stringify-stringify-using-a-custom-naming-convention).
+
+See more examples of creating presets in the `@bem/sdk.naming.presets` package [documentation](https://github.com/bem/bem-sdk/tree/master/packages/naming.presets).


### PR DESCRIPTION
Also, I add some fixes in README for naming.cell.stringify package

See `naming.file.stringify` documentation here
https://github.com/bem/bem-sdk/tree/migelle-file-stringify/packages/naming.file.stringify