### PR TITLE
Grammar and typos

### DIFF
--- a/packages/naming.cell.match/README.md
+++ b/packages/naming.cell.match/README.md
@@ -153,10 +153,10 @@ match(incorrectPath);
 
 ```js
 /**
- * @typedef BemCell — representation of cell.
- * @property {BemEntityName} entity — representation of entity name.
- * @property {string} tech - tech of cell.
- * @property {string} [obj.layer] - layer of cell.
+ * @typedef BemCell — Representation of cell.
+ * @property {BemEntityName} entity — Representation of entity name.
+ * @property {string} tech — Tech of cell.
+ * @property {string} [obj.layer] — Layer of cell.
  */
 
 /**
@@ -167,7 +167,7 @@ match(incorrectPath);
  * - isMatch — `true` if the path matches a BEM cell and `false` if not.
  * - rest — some additional text at the end of the path. If the value is not `null` then `isMatch` value will be `false`.
  *
- * @param {string} path - object representation of BEM cell.
+ * @param {string} path — Object representation of BEM cell.
  * @returns {cell: ?BemCell, isMatch: boolean, rest: ?string}
  */
 match(path);

--- a/packages/naming.cell.match/README.md
+++ b/packages/naming.cell.match/README.md
@@ -42,8 +42,8 @@ To run the `@bem/sdk.naming.cell.match` package:
 
 Install the following packages:
 
-* [@bem/sdk.naming.cell.match](https://www.npmjs.org/package/@bem/sdk.naming.cell.match) that makes the `match()` function.
-* [@bem/sdk.naming.presets](https://www.npmjs.com/package/@bem/sdk.naming.presets) that contains presets with well-known naming conventions.
+* [@bem/sdk.naming.cell.match](https://www.npmjs.org/package/@bem/sdk.naming.cell.match), which makes the `match()` function.
+* [@bem/sdk.naming.presets](https://www.npmjs.com/package/@bem/sdk.naming.presets), which contains presets with well-known naming conventions.
 
 To install these packages, run the following command:
 

--- a/packages/naming.cell.pattern-parser/README.md
+++ b/packages/naming.cell.pattern-parser/README.md
@@ -42,8 +42,8 @@ To run the `@bem/sdk.naming.cell.pattern-parser` package:
 
 Install the following packages:
 
-* [@bem/sdk.naming.cell.pattern-parser](https://www.npmjs.org/package/@bem/sdk.naming.cell.pattern-parser) that contains the `parse()` function.
-* [@bem/sdk.naming.presets](https://www.npmjs.com/package/@bem/sdk.naming.presets) that contains presets with well-known naming conventions.
+* [@bem/sdk.naming.cell.pattern-parser](https://www.npmjs.org/package/@bem/sdk.naming.cell.pattern-parser), which contains the `parse()` function.
+* [@bem/sdk.naming.presets](https://www.npmjs.com/package/@bem/sdk.naming.presets), which contains presets with well-known naming conventions.
 
 To install the packages, run the following command:
 

--- a/packages/naming.cell.pattern-parser/README.md
+++ b/packages/naming.cell.pattern-parser/README.md
@@ -84,9 +84,9 @@ parse(originNaming.fs.pattern);
 /**
  * Parses a path pattern into array representation.
  *
- * @param {string} pattern - template-string-like pattern that describes
+ * @param {string} pattern — Template-string-like pattern that describes
  *                           the file structure organization of a BEM project.
- * @returns {Array} — array with separated elements from the pattern.
+ * @returns {Array} — Array with separated elements from the pattern.
  */
 parse(pattern);
 ```

--- a/packages/naming.cell.stringify/README.md
+++ b/packages/naming.cell.stringify/README.md
@@ -145,17 +145,17 @@ console.log(stringify(myBemCell));
 
 ```js
 /**
- * @typedef BemCell — representation of cell.
- * @property {BemEntityName} entity — representation of entity name.
- * @property {string} tech - tech of cell.
- * @property {string} [obj.layer] - layer of cell.
+ * @typedef BemCell — Representation of cell.
+ * @property {BemEntityName} entity — Representation of entity name.
+ * @property {string} tech — Tech of cell.
+ * @property {string} [obj.layer] — Layer of cell.
  */
 
 /**
  * Forms a file according to object representation of BEM cell.
  *
- * @param {Object|BemCell} cell - object representation of BEM cell.
- * @returns {string} - file path for the BEM cell. This name can be used in class attributes.
+ * @param {Object|BemCell} cell — Object representation of BEM cell.
+ * @returns {string} — File path for the BEM cell. This name can be used in class attributes.
  */
 stringify(cell);
 ```

--- a/packages/naming.cell.stringify/README.md
+++ b/packages/naming.cell.stringify/README.md
@@ -17,7 +17,7 @@ Stringifier for a BEM cell object.
 
 Stringify returns the file path for a specified BEM cell object.
 
-You can choose a preset with [naming convention](https://en.bem.info/methodology/naming-convention/) for creating a `stingify()` function. See the full list of supported presets in the `@bem/sdk.naming.presets` package [documentation](https://github.com/bem/bem-sdk/tree/master/packages/naming.presets#naming-conventions).
+You can choose a preset with [naming convention](https://en.bem.info/methodology/naming-convention/) for creating a `stringify()` function. See the full list of supported presets in the `@bem/sdk.naming.presets` package [documentation](https://github.com/bem/bem-sdk/tree/master/packages/naming.presets#naming-conventions).
 
 All provided presets uses the [`nested`](https://en.bem.info/methodology/filestructure/#nested) file structure scheme. To use the [`flat`](https://en.bem.info/methodology/filestructure/#flat) scheme that is better for small projects, see [Using a custom naming convention](#using-a-custom-naming-convention) section.
 
@@ -42,9 +42,9 @@ To run the `@bem/sdk.naming.cell.stringify` package:
 
 Install the following packages:
 
-* [@bem/sdk.naming.cell.stringify](https://www.npmjs.org/package/@bem/sdk.naming.cell.stringify) that makes the `stingify()` function.
-* [@bem/sdk.naming.presets](https://www.npmjs.com/package/@bem/sdk.naming.presets) that contains presets with well-known naming conventions.
-* [@bem/sdk.cell](https://www.npmjs.com/package/@bem/sdk.cell) that allows you create a BEM cell objects to stringify.
+* [@bem/sdk.naming.cell.stringify](https://www.npmjs.org/package/@bem/sdk.naming.cell.stringify), which makes the `stringify()` function.
+* [@bem/sdk.naming.presets](https://www.npmjs.com/package/@bem/sdk.naming.presets), which contains presets with well-known naming conventions.
+* [@bem/sdk.cell](https://www.npmjs.com/package/@bem/sdk.cell), which allows you create a BEM cell objects to stringify.
 
 To install these packages, run the following command:
 
@@ -168,7 +168,7 @@ To create a preset with a custom naming convention use the `create()` function f
 
 For example create a preset that uses [flat](https://en.bem.info/methodology/filestructure/#flat) scheme to describe a file structure organization.
 
-Use the created preset to make your `stingify()` function.
+Use the created preset to make your `stringify()` function.
 
 **Example:**
 

--- a/packages/naming.entity.parse/README.md
+++ b/packages/naming.entity.parse/README.md
@@ -44,8 +44,8 @@ To run the `@bem/sdk.naming.entity.parse` package:
 
 Install the following packages:
 
-* [@bem/sdk.naming.entity.parse](https://www.npmjs.org/package/@bem/sdk.naming.entity.parse) that contains the `parse()` function.
-* [@bem/sdk.naming.presets](https://www.npmjs.com/package/@bem/sdk.naming.presets) that contains presets with well-known naming conventions.
+* [@bem/sdk.naming.entity.parse](https://www.npmjs.org/package/@bem/sdk.naming.entity.parse), which contains the `parse()` function.
+* [@bem/sdk.naming.presets](https://www.npmjs.com/package/@bem/sdk.naming.presets), which contains presets with well-known naming conventions.
 
 To install the packages, run the following command:
 
@@ -130,7 +130,7 @@ parse('my-block__my-element_my-modifier_some-value').valueOf();
 /**
  * Parses string into object representation.
  *
- * @param {string} str - string representation of BEM entity.
+ * @param {string} str - string representation of a BEM entity.
  * @returns {(BemEntityName|undefined)}
  */
 parse(str);

--- a/packages/naming.entity.parse/README.md
+++ b/packages/naming.entity.parse/README.md
@@ -120,17 +120,17 @@ parse('my-block__my-element_my-modifier_some-value').valueOf();
 ```js
 /**
  * @typedef BemEntityName
- * @property {string} block — block name.
- * @property {string} [elem] — element name.
- * @property {Object} [mod] — modifier name or object with name and value.
- * @property {string} mod.name — modifier name.
+ * @property {string} block — Block name.
+ * @property {string} [elem] — Element name.
+ * @property {Object} [mod] — Modifier name or object with name and value.
+ * @property {string} mod.name — Modifier name.
  * @property {string} [mod.val=true] — modifier value.
  */
 
 /**
  * Parses string into object representation.
  *
- * @param {string} str - string representation of a BEM entity.
+ * @param {string} str — String representation of a BEM entity.
  * @returns {(BemEntityName|undefined)}
  */
 parse(str);

--- a/packages/naming.entity/README.md
+++ b/packages/naming.entity/README.md
@@ -149,7 +149,7 @@ This function parses the string with a BEM entity name into object representatio
 /**
  * Parses string into object representation.
  *
- * @param {string} str - string representation of BEM entity.
+ * @param {string} str - string representation of a BEM entity.
  * @returns {(BemEntityName|undefined)}
  */
 parse(str);
@@ -185,9 +185,9 @@ This function forms a string from the object that specifies a BEM entity name.
  */
 
 /**
- * Forms a string according to object representation of BEM entity.
+ * Forms a string according to object representation of a BEM entity.
  *
- * @param {object|BemEntityName} entity - object representation of BEM entity.
+ * @param {object|BemEntityName} entity - object representation of a BEM entity.
  * @returns {string} - BEM entity name. This name can be used in class attributes.
  */
 stringify(entity);

--- a/packages/naming.entity/README.md
+++ b/packages/naming.entity/README.md
@@ -94,29 +94,29 @@ This function creates a `naming.entity` instance with the [parse()](#parse) and 
 ```js
 /**
  * @typedef INamingConventionDelims
- * @property {string} elem — separates an element name from block.
- * @property {string|Object} mod — separates a modifier name and the value of a modifier.
- * @property {string} mod.name — separates a modifier name from a block or an element.
- * @property {string|boolean} mod.val — separates the value of a modifier from the modifier name.
+ * @property {string} elem — Separates an element name from block.
+ * @property {string|Object} mod — Separates a modifier name and the value of a modifier.
+ * @property {string} mod.name — Separates a modifier name from a block or an element.
+ * @property {string|boolean} mod.val — Separates the value of a modifier from the modifier name.
  */
 
 /**
  * Returns created  with the specified naming convention.
  *
- * @param {(Object|string)} [options] — user options or the name of preset to return.
+ * @param {(Object|string)} [options] — User options or the name of preset to return.
  *                                      If not specified, default preset will be returned.
- * @param {string} [options.preset] — preset name that should be used as default preset.
- * @param {Object} [options.delims] — strings to separate names of bem entities.
+ * @param {string} [options.preset] — Preset name that should be used as default preset.
+ * @param {Object} [options.delims] — Strings to separate names of bem entities.
  *                                    This object has the same structure with `INamingConventionDelims`,
  *                                    but all properties inside are optional.
- * @param {Object} [options.fs] — user options to separate names of files with bem entities.
- * @param {Object} [options.fs.delims] — strings to separate names of files in a BEM project.
+ * @param {Object} [options.fs] — User options to separate names of files with bem entities.
+ * @param {Object} [options.fs.delims] — Strings to separate names of files in a BEM project.
  *                                       This object has the same structure with `INamingConventionDelims`,
  *                                       but all properties inside are optional.
- * @param {string} [options.fs.pattern] — pattern that describes the file structure of a BEM project.s
- * @param {string} [options.fs.scheme] — schema name that describes the file structure of one BEM entity.
- * @param {string} [options.wordPattern] — a regular expression that will be used to match an entity name.
- * @returns {INamingConvention} — an object with `delims`, `fs` and `wordPattern` properties
+ * @param {string} [options.fs.pattern] — Pattern that describes the file structure of a BEM project.s
+ * @param {string} [options.fs.scheme] — Schema name that describes the file structure of one BEM entity.
+ * @param {string} [options.wordPattern] — A regular expression that will be used to match an entity name.
+ * @returns {INamingConvention} — An object with `delims`, `fs` and `wordPattern` properties
  *                                that describes the naming convention.
  */
 create(options);
@@ -139,17 +139,17 @@ This function parses the string with a BEM entity name into object representatio
 ```js
 /**
  * @typedef BemEntityName
- * @property {string} block — block name.
- * @property {string} [elem] — element name.
- * @property {string|Object} [mod] — modifier name or object with name and value.
- * @property {string} mod.name — modifier name.
- * @property {string} [mod.val=true] — modifier value.
+ * @property {string} block — Block name.
+ * @property {string} [elem] — Element name.
+ * @property {string|Object} [mod] — Modifier name or object with name and value.
+ * @property {string} mod.name — Modifier name.
+ * @property {string} [mod.val=true] — Modifier value.
  */
 
 /**
  * Parses string into object representation.
  *
- * @param {string} str - string representation of a BEM entity.
+ * @param {string} str — String representation of a BEM entity.
  * @returns {(BemEntityName|undefined)}
  */
 parse(str);
@@ -177,18 +177,18 @@ This function forms a string from the object that specifies a BEM entity name.
 ```js
 /**
  * @typedef BemEntityName
- * @property {string} block — block name.
- * @property {string} [elem] — element name.
- * @property {string|Object} [mod] — modifier name or object with name and value.
- * @property {string} mod.name — modifier name.
- * @property {string|boolean} [mod.val] — modifier value.
+ * @property {string} block — Block name.
+ * @property {string} [elem] — Element name.
+ * @property {string|Object} [mod] — Modifier name or object with name and value.
+ * @property {string} mod.name — Modifier name.
+ * @property {string|boolean} [mod.val] — Modifier value.
  */
 
 /**
  * Forms a string according to object representation of a BEM entity.
  *
- * @param {object|BemEntityName} entity - object representation of a BEM entity.
- * @returns {string} - BEM entity name. This name can be used in class attributes.
+ * @param {object|BemEntityName} entity — Object representation of a BEM entity.
+ * @returns {string} — BEM entity name. This name can be used in class attributes.
  */
 stringify(entity);
 ```

--- a/packages/naming.file.stringify/README.md
+++ b/packages/naming.file.stringify/README.md
@@ -143,17 +143,17 @@ console.log(stringify(myFile));
 
 ```js
 /**
- * @typedef BemFile — representation of file.
- * @property {BemCell} cell — representation of a BEM cell.
- * @property {String} [level] - base level path.
- * @property {String} [path] - path to file.
+ * @typedef BemFile — Representation of file.
+ * @property {BemCell} cell — Representation of a BEM cell.
+ * @property {String} [level] — Base level path.
+ * @property {String} [path] — Path to file.
  */
 
 /**
  * Forms a file according to object representation of BEM file.
  *
- * @param {Object|BemFile} file - object representation of BEM file.
- * @returns {string} - file path.
+ * @param {Object|BemFile} file — Object representation of BEM file.
+ * @returns {string} — File path.
  */
 stringify(file);
 ```

--- a/packages/naming.file.stringify/README.md
+++ b/packages/naming.file.stringify/README.md
@@ -17,7 +17,7 @@ Stringifier for a BEM file.
 
 Stringify returns the file path for a specified BEM file object.
 
-You can choose a preset with [naming convention](https://en.bem.info/methodology/naming-convention/) for creating a `stingify()` function. See the full list of supported presets in the `@bem/sdk.naming.presets` package [documentation](https://github.com/bem/bem-sdk/tree/master/packages/naming.presets#naming-conventions).
+You can choose a preset with [naming convention](https://en.bem.info/methodology/naming-convention/) for creating a `stringify()` function. See the full list of supported presets in the `@bem/sdk.naming.presets` package [documentation](https://github.com/bem/bem-sdk/tree/master/packages/naming.presets#naming-conventions).
 
 All provided presets uses the [`nested`](https://en.bem.info/methodology/filestructure/#nested) file structure scheme. To use the [`flat`](https://en.bem.info/methodology/filestructure/#flat) scheme that is better for small projects, see [Using a custom naming convention](#using-a-custom-naming-convention) section.
 
@@ -42,9 +42,9 @@ To run the `@bem/sdk.naming.file.stringify` package:
 
 Install the following packages:
 
-* [@bem/sdk.naming.file.stringify](https://www.npmjs.org/package/@bem/sdk.naming.file.stringify) that makes the `stingify()` function.
-* [@bem/sdk.naming.presets](https://www.npmjs.com/package/@bem/sdk.naming.presets) that contains presets with well-known naming conventions.
-* [@bem/sdk.file](https://www.npmjs.com/package/@bem/sdk.file) that allows you create a BEM file objects to stringify.
+* [@bem/sdk.naming.file.stringify](https://www.npmjs.org/package/@bem/sdk.naming.file.stringify), which makes the `stringify()` function.
+* [@bem/sdk.naming.presets](https://www.npmjs.com/package/@bem/sdk.naming.presets), which contains presets with well-known naming conventions.
+* [@bem/sdk.file](https://www.npmjs.com/package/@bem/sdk.file), which allows you create a BEM file objects to stringify.
 
 To install these packages, run the following command:
 
@@ -166,7 +166,7 @@ To create a preset with a custom naming convention use the `create()` function f
 
 For example create a preset that uses [`flat`](https://en.bem.info/methodology/filestructure/#flat) scheme to describe a file structure organization.
 
-Use the created preset to make your `stingify()` function.
+Use the created preset to make your `stringify()` function.
 
 **Example:**
 

--- a/packages/naming.presets/README.md
+++ b/packages/naming.presets/README.md
@@ -134,31 +134,31 @@ parse('my-block_my-modifier=some-value');
 ```js
 /**
  * @typedef INamingConventionDelims
- * @property {string} elem — separates an element name from block.
- * @property {string|Object} mod — separates a modifier name and the value of a modifier.
- * @property {string} mod.name — separates a modifier name from a block or an element.
- * @property {string|boolean} mod.val — separates the value of a modifier from the modifier name.
+ * @property {string} elem — Separates an element name from block.
+ * @property {string|Object} mod — Separates a modifier name and the value of a modifier.
+ * @property {string} mod.name — Separates a modifier name from a block or an element.
+ * @property {string|boolean} mod.val — Separates the value of a modifier from the modifier name.
  */
 
 /**
  * Returns created preset with the specified naming convention.
  *
- * @param {(Object|string)} [options] — user options or the name of preset to return.
+ * @param {(Object|string)} [options] — User options or the name of preset to return.
  *                                      If not specified, default preset will be returned.
- * @param {string} [options.preset] — preset name that should be used as default preset.
- * @param {Object} [options.delims] — strings to separate names of bem entities.
+ * @param {string} [options.preset] — Preset name that should be used as default preset.
+ * @param {Object} [options.delims] — Strings to separate names of bem entities.
  *                                    This object has the same structure with `INamingConventionDelims`,
  *                                    but all properties inside are optional.
- * @param {Object} [options.fs] — user options to separate names of files with bem entities.
- * @param {Object} [options.fs.delims] — strings to separate names of files in a BEM project.
+ * @param {Object} [options.fs] — User options to separate names of files with bem entities.
+ * @param {Object} [options.fs.delims] — Strings to separate names of files in a BEM project.
  *                                       This object has the same structure with `INamingConventionDelims`,
  *                                       but all properties inside are optional.
- * @param {string} [options.fs.pattern] — pattern that describes the file structure of a BEM project.s
- * @param {string} [options.fs.scheme] — schema name that describes the file structure of one BEM entity.
- * @param {string} [options.wordPattern] — a regular expression that will be used to match an entity name.
- * @param {(Object|string)} [userDefaults] — user default options or the name of preset to use.
+ * @param {string} [options.fs.pattern] — Pattern that describes the file structure of a BEM project.s
+ * @param {string} [options.fs.scheme] — Schema name that describes the file structure of one BEM entity.
+ * @param {string} [options.wordPattern] — A regular expression that will be used to match an entity name.
+ * @param {(Object|string)} [userDefaults] — User default options or the name of preset to use.
  *                                           If the name of preset incorrect `origin` preset will be used.
- * @returns {INamingConvention} — an object with `delims`, `fs` and `wordPattern` properties
+ * @returns {INamingConvention} — An object with `delims`, `fs` and `wordPattern` properties
  *                                that describes the naming convention.
  */
 create(options, userDefaults);


### PR DESCRIPTION
После того, как Эми проверила naming.entity.stringify, поправил типичные ошибки, опечатки.
Помимо этого исправил стиль комментариев в API Reference. Предварительно обсудили с Серёжей.