### PR TITLE
moved function descriptions from the JSDoc comments to the first paragraph

### DIFF
--- a/packages/naming.cell.match/README.md
+++ b/packages/naming.cell.match/README.md
@@ -151,6 +151,15 @@ match(incorrectPath);
 
 ### match()
 
+Tries to convert the specified path to a BEM cell object and return an object that contains the result.
+
+The returned object has the follow properties:
+
+* `cell` — converted BEM cell.
+* `isMatch` — `true` if the path matches a BEM cell and `false` if not.
+* `rest` — some additional text at the end of the path. If the value is not `null` then the `isMatch` value will be `false`.
+
+
 ```js
 /**
  * @typedef BemCell — Representation of cell.
@@ -160,13 +169,6 @@ match(incorrectPath);
  */
 
 /**
- * Tries to convert the specified path to a BEM cell object and return an object that contains the result.
- *
- * The returned object has the follow properties:
- * - cell — converted BEM cell.
- * - isMatch — `true` if the path matches a BEM cell and `false` if not.
- * - rest — some additional text at the end of the path. If the value is not `null` then the `isMatch` value will be `false`.
- *
  * @param {string} path — Object representation of the BEM cell.
  * @returns {cell: ?BemCell, isMatch: boolean, rest: ?string}
  */

--- a/packages/naming.cell.pattern-parser/README.md
+++ b/packages/naming.cell.pattern-parser/README.md
@@ -80,10 +80,10 @@ parse(originNaming.fs.pattern);
 
 ### parse()
 
+Parses a path pattern into array representation.
+
 ```js
 /**
- * Parses a path pattern into array representation.
- *
  * @param {string} pattern — Template-string-like pattern that describes
  *                           the file structure organization of a BEM project.
  * @returns {Array} — Array with separated elements from the pattern.

--- a/packages/naming.cell.stringify/README.md
+++ b/packages/naming.cell.stringify/README.md
@@ -143,6 +143,8 @@ console.log(stringify(myBemCell));
 
 ### stringify()
 
+Forms a file according to object representation of BEM cell.
+
 ```js
 /**
  * @typedef BemCell — Representation of cell.
@@ -152,8 +154,6 @@ console.log(stringify(myBemCell));
  */
 
 /**
- * Forms a file according to object representation of BEM cell.
- *
  * @param {Object|BemCell} cell — Object representation of BEM cell.
  * @returns {string} — File path for the BEM cell. This name can be used in class attributes.
  */

--- a/packages/naming.entity.parse/README.md
+++ b/packages/naming.entity.parse/README.md
@@ -117,6 +117,8 @@ parse('my-block__my-element_my-modifier_some-value').valueOf();
 
 ### parse()
 
+Parses string into object representation.
+
 ```js
 /**
  * @typedef BemEntityName
@@ -128,8 +130,6 @@ parse('my-block__my-element_my-modifier_some-value').valueOf();
  */
 
 /**
- * Parses string into object representation.
- *
  * @param {string} str — String representation of a BEM entity.
  * @returns {(BemEntityName|undefined)}
  */

--- a/packages/naming.entity.stringify/README.md
+++ b/packages/naming.entity.stringify/README.md
@@ -106,6 +106,8 @@ console.log(stringify({ block: 'my-block',
 
 ### stringify()
 
+Forms a string based on the object representation of a BEM entity.
+
 ```js
 /**
  * @typedef BemEntityName
@@ -117,8 +119,6 @@ console.log(stringify({ block: 'my-block',
  */
 
 /**
- * Forms a string based on the object representation of a BEM entity.
- *
  * @param {object|BemEntityName} entity — Object representation of the BEM entity.
  * @returns {string} — Name of the BEM entity. This name can be used in class attributes.
  */

--- a/packages/naming.entity/README.md
+++ b/packages/naming.entity/README.md
@@ -134,7 +134,7 @@ See more examples in the [Parameter tuning](#parameter-tuning) section.
 
 ### parse()
 
-This function parses the string with a BEM entity name into an object representation.
+Parses the string with a BEM entity name into an object representation.
 
 ```js
 /**
@@ -147,8 +147,6 @@ This function parses the string with a BEM entity name into an object representa
  */
 
 /**
- * Parses string into object representation.
- *
  * @param {string} str — String representation of a BEM entity.
  * @returns {(BemEntityName|undefined)}
  */
@@ -172,7 +170,7 @@ For more information about the `parse()` function, see the `@bem/sdk.naming.pars
 
 ### stringify()
 
-This function forms a string from the object that specifies a BEM entity name.
+Forms a string from the object that specifies a BEM entity name.
 
 ```js
 /**
@@ -185,8 +183,6 @@ This function forms a string from the object that specifies a BEM entity name.
  */
 
 /**
- * Forms a string according to object representation of a BEM entity.
- *
  * @param {object|BemEntityName} entity — Object representation of a BEM entity.
  * @returns {string} — BEM entity name. This name can be used in class attributes.
  */

--- a/packages/naming.file.stringify/README.md
+++ b/packages/naming.file.stringify/README.md
@@ -141,6 +141,8 @@ console.log(stringify(myFile));
 
 ### stringify()
 
+Forms a file according to object representation of BEM file.
+
 ```js
 /**
  * @typedef BemFile — Representation of file.
@@ -150,8 +152,6 @@ console.log(stringify(myFile));
  */
 
 /**
- * Forms a file according to object representation of BEM file.
- *
  * @param {Object|BemFile} file — Object representation of BEM file.
  * @returns {string} — File path.
  */

--- a/packages/naming.presets/README.md
+++ b/packages/naming.presets/README.md
@@ -131,6 +131,14 @@ parse('my-block_my-modifier=some-value');
 
 #### create()
 
+Creates a preset with the specified naming convention.
+
+This function will get all options from the default preset, overwrite them with the passed options and return the result. Options are overwritten in the following order:
+
+1. Options from the default preset.
+2. Options from the `userDefaults` parameter.
+3. Options from the `options` parameter.
+
 ```js
 /**
  * @typedef INamingConventionDelims
@@ -163,12 +171,6 @@ parse('my-block_my-modifier=some-value');
  */
 create(options, userDefaults);
 ```
-
-This function will get all options from the default preset, overwrite them with the passed options and return the result. Options are overwritten in the following order:
-
-1. Options from the default preset.
-2. Options from the `userDefaults` parameter.
-3. Options from the `options` parameter.
 
 ## Parameter tuning
 


### PR DESCRIPTION
В graph Серёжа попросил вынести описание функции из комментария в формате JSDoc в начало раздела.
Сделал то же самое во всех остальных пакетах.

Текст практически не изменял. Думаю, это можно не проверять.