### PR TITLE
Fix default values for the save() function in the decl package

### DIFF
--- a/packages/decl/lib/formats/enb/format.js
+++ b/packages/decl/lib/formats/enb/format.js
@@ -25,8 +25,5 @@ module.exports = function (cells) {
         return tmp;
     });
 
-    return {
-        format: 'enb',
-        deps: decl
-    };
+    return decl;
 };

--- a/packages/decl/lib/formats/v2/format.js
+++ b/packages/decl/lib/formats/v2/format.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../enb/format');

--- a/packages/decl/lib/formats/v2/index.js
+++ b/packages/decl/lib/formats/v2/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
 module.exports = {
+    format: require('./format'),
     parse: require('./parse')
 };

--- a/packages/decl/lib/stringify.js
+++ b/packages/decl/lib/stringify.js
@@ -14,7 +14,7 @@ const DEFAULTS = { exportType: 'json', space: 4 };
 const fieldByFormat = {
     v1: 'blocks',
     enb: 'deps',
-    v2: ''
+    v2: 'deps'
 };
 
 const generators = {

--- a/packages/decl/lib/stringify.js
+++ b/packages/decl/lib/stringify.js
@@ -13,8 +13,8 @@ const DEFAULTS = { exportType: 'json', space: 4 };
 // which called from parse method.
 const fieldByFormat = {
     v1: 'blocks',
-    enb: '',
-    v2: 'deps'
+    enb: 'deps',
+    v2: ''
 };
 
 const generators = {

--- a/packages/decl/lib/stringify.js
+++ b/packages/decl/lib/stringify.js
@@ -25,6 +25,7 @@ const generators = {
 };
 // Aliases
 generators.es6 = generators.es2015;
+generators.cjs = generators.commonjs;
 
 /**
  * Create string representation of declaration

--- a/packages/decl/test/formats/enb/format.test.js
+++ b/packages/decl/test/formats/enb/format.test.js
@@ -14,7 +14,7 @@ describe('decl.formats.enb.format', () => {
 
         const formatted = format(cells);
 
-        assert.deepEqual(formatted, { format: 'enb', deps: [{ block: 'block' }] });
+        assert.deepEqual(formatted, [{ block: 'block' }]);
     });
 
     it('should format block with tech', () => {
@@ -22,7 +22,7 @@ describe('decl.formats.enb.format', () => {
 
         const formatted = format(cells);
 
-        assert.deepEqual(formatted, { format: 'enb', deps: [{ block: 'block', tech: 'tech' }] });
+        assert.deepEqual(formatted, [{ block: 'block', tech: 'tech' }]);
     });
 
     it('should format elem', () => {
@@ -30,7 +30,7 @@ describe('decl.formats.enb.format', () => {
 
         const formatted = format(cells);
 
-        assert.deepEqual(formatted, { format: 'enb', deps: [{ block: 'block', elem: 'elem' }] });
+        assert.deepEqual(formatted, [{ block: 'block', elem: 'elem' }]);
     });
 
     it('should format mod', () => {
@@ -38,7 +38,7 @@ describe('decl.formats.enb.format', () => {
 
         const formatted = format(cells);
 
-        assert.deepEqual(formatted, { format: 'enb', deps: [{ block: 'block', mod: 'mod', val: 'val' }] });
+        assert.deepEqual(formatted, [{ block: 'block', mod: 'mod', val: 'val' }]);
     });
 
     it('should format simple mod', () => {
@@ -46,7 +46,7 @@ describe('decl.formats.enb.format', () => {
 
         const formatted = format(cells);
 
-        assert.deepEqual(formatted, { format: 'enb', deps: [{ block: 'block', mod: 'mod' }] });
+        assert.deepEqual(formatted, [{ block: 'block', mod: 'mod' }]);
     });
 
     it('should format elem mod', () => {
@@ -54,7 +54,7 @@ describe('decl.formats.enb.format', () => {
 
         const formatted = format(cells);
 
-        assert.deepEqual(formatted, { format: 'enb', deps: [{ block: 'block', elem: 'elem', mod: 'mod', val: 'val' }] });
+        assert.deepEqual(formatted, [{ block: 'block', elem: 'elem', mod: 'mod', val: 'val' }]);
     });
 
     it('should format elem simple mod', () => {
@@ -62,6 +62,6 @@ describe('decl.formats.enb.format', () => {
 
         const formatted = format(cells);
 
-        assert.deepEqual(formatted, { format: 'enb', deps: [{ block: 'block', elem: 'elem', mod: 'mod' }] });
+        assert.deepEqual(formatted, [{ block: 'block', elem: 'elem', mod: 'mod' }]);
     });
 });

--- a/packages/deps/lib/gather.js
+++ b/packages/deps/lib/gather.js
@@ -17,12 +17,12 @@ module.exports = async function ({ platform = 'desktop', defaults = {}, config }
     assert(!Array.isArray(config.levels), 'Please pass config into deps/gather as field (`{config}`)');
 
     const [ levels, levelMap ] = await Promise.all([
-        config.levels(platform).map(l => l.path || l),
+        config.levels(platform),
         config.levelMap(),
     ]);
 
     return new Promise(async (resolve, reject) => {
-        const walker = walk(await levels, { levels: levelMap, defaults });
+        const walker = walk(levels.map(l => l.path || l), { levels: levelMap, defaults });
         const res = [];
         let filesCount = 1;
         let rejected =  false;

--- a/packages/deps/lib/gather.js
+++ b/packages/deps/lib/gather.js
@@ -1,16 +1,28 @@
 'use strict';
 
-const walk = require('@bem/sdk.walk');
+const assert = require('assert');
 const fs = require('fs');
+
+const Config = require('@bem/sdk.config');
+const walk = require('@bem/sdk.walk');
 
 /**
  * Gathering deps.js files with bem-walk
  * @param {BemConfig} config
  * @returns {Promise<Array<BemFile>>}
  */
-module.exports = function (config) {
-    return new Promise((resolve, reject) => {
-        const walker = walk(config.levels, { defaults: config.options });
+module.exports = async function ({ platform = 'desktop', defaults = {}, config }) {
+    config || (config = Config());
+
+    assert(!Array.isArray(config.levels), 'Please pass config into deps/gather as field (`{config}`)');
+
+    const [ levels, levelMap ] = await Promise.all([
+        config.levels(platform).map(l => l.path || l),
+        config.levelMap(),
+    ]);
+
+    return new Promise(async (resolve, reject) => {
+        const walker = walk(await levels, { levels: levelMap, defaults });
         const res = [];
         let filesCount = 1;
         let rejected =  false;

--- a/packages/deps/package.json
+++ b/packages/deps/package.json
@@ -29,6 +29,7 @@
     "lib/**"
   ],
   "dependencies": {
+    "@bem/sdk.config": "*",
     "@bem/sdk.decl": "^0.3.8",
     "@bem/sdk.entity-name": "^0.2.10",
     "@bem/sdk.graph": "^0.3.1",

--- a/packages/deps/test/gather.test.js
+++ b/packages/deps/test/gather.test.js
@@ -21,10 +21,11 @@ describe('gather', () => {
         });
 
         const config = {
-            levels: ['common.blocks']
+            levels: () => ['common.blocks'],
+            levelMap: () => ({'common.blocks': {}})
         };
 
-        return gather(config).then(data =>
+        return gather({ config }).then(data =>
             expect(data).to.deep.equal([])
         );
     });
@@ -35,10 +36,11 @@ describe('gather', () => {
         });
 
         const config = {
-            levels: ['common.blocks']
+            levels: () => ['common.blocks'],
+            levelMap: () => ({'common.blocks': {}})
         };
 
-        return gather(config).then(data => {
+        return gather({ config }).then(data => {
             expect(data.map(f => f.cell.id)).to.deep.equal([
                 'button@common.deps.js'
             ]);
@@ -53,10 +55,11 @@ describe('gather', () => {
         });
 
         const config = {
-            levels: ['common.blocks', 'desktop.blocks']
+            levels: () => ['common.blocks', 'desktop.blocks'],
+            levelMap: () => ({'common.blocks': {}})
         };
 
-        return gather(config).then(data =>
+        return gather({ config }).then(data =>
             expect(data.map(f => f.cell.id)).to.deep.equal([
                 'button@common.deps.js',
                 'input@common.deps.js',


### PR DESCRIPTION
С такими значениями по умолчанию метод save не работает:
1. Для формата `v2` нет файла format.js, поэтому валится с исключением [isNotSupported](https://github.com/bem/bem-sdk/blob/master/packages/decl/lib/formats/index.js#L10).
2. Для `exportType='cjs'` не задан соответствующий алиас в файле stringify.js. Надо либо алиас добавить (что я и сделал), либо заменить на `commonjs` в значениях по умолчанию и поправить тесты `save.test.js`.